### PR TITLE
"SoftwareDistribution\Download" path has been added for CacheCleanupTool.

### DIFF
--- a/Glow/glow_tools/GlowCacheCleanupTool.cs
+++ b/Glow/glow_tools/GlowCacheCleanupTool.cs
@@ -59,6 +59,7 @@ namespace Glow.glow_tools{
             CCT_L1.Text = clean_path_list[0];
             CCT_L3.Text = clean_path_list[1];
             CCT_L5.Text = clean_path_list[2];
+            CCT_XX.Text = clean_path_list[3]; // The "XX" part must be edited for the required object name.
             // START FOLDER SIZE CHECK ALGORITHM
             Task check_folder_sizes_task = new Task(check_folder_sizes);
             check_folder_sizes_task.Start();

--- a/Glow/glow_tools/GlowCacheCleanupTool.cs
+++ b/Glow/glow_tools/GlowCacheCleanupTool.cs
@@ -18,7 +18,8 @@ namespace Glow.glow_tools{
         static string clean_path_1 = @"C:\Windows\Temp";
         static string clean_path_2 = @"C:\Users\" + SystemInformation.UserName + @"\AppData\Local\Temp";
         static string clean_path_3 = @"C:\Windows\Prefetch";
-        List<string> clean_path_list = new List<string>() { clean_path_1, clean_path_2, clean_path_3 };
+        static string clean_path_4 = @"C:\Windows\SoftwareDistribution\Download"; // Distributing software used for Windows update cleans the \Download folder, this process is safe. (This should not be done while updating with Windows update!)
+        List<string> clean_path_list = new List<string>() { clean_path_1, clean_path_2, clean_path_3 , clean_path_4 };
         List<double> clean_path_size_list = new List<double>();
         string cct_title;
         bool cct_auto_refresh_mode = true;


### PR DESCRIPTION
"SoftwareDistribution\Download" path has been added for CacheCleanupTool. This is the software distribution folder used for Windows update. There is no harm in cleaning it. (Do not run while updating!) @roines45

WARNING: The "XX" part must be edited for the required object name. [CCT_XX.Text = clean_path_list[3];]